### PR TITLE
eliminar 'other-resolution' en vista movil

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
     </div>
 
     <main>
-        <article>
+        <article class="other-resolution">
             <div class="container">
                 <div class="row">
                     <div class="col-6">

--- a/style.css
+++ b/style.css
@@ -28,12 +28,19 @@ html, body{
 
 @media (max-width: 600px) {
 
+    .other-resolution{
+        display: none;
+    }
+
+    body{
+        overflow-y: hidden;    
+    }
+
     header {
         width: 100%;
         height: 55%;
         position: relative;
         background-size: cover;
-        background-color: blueviolet;
         background-position: center;
         background-image: url('assets/shang_chi.png');
     }


### PR DESCRIPTION
Se quito el <article> con la clase 'other-resolution' para que no interfiriera en la vista móvil